### PR TITLE
Always build as `-arch x86_64` (for now)

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -162,6 +162,8 @@ impl Compiler {
         #[cfg(target_os = "macos")]
         let output = Command::new("cc")
             .args([
+                "-arch",
+                "x86_64",
                 "-o",
                 &target.to_string(),
                 &format!("{}.o", target.to_string()),


### PR DESCRIPTION
Since we only support x86_64 for now, we should pass it explicitly to make sure that x86_64 binaries are generated on Apple Silicon Macs too (which then run under Rosetta).