### PR TITLE
Run CI only on push and format/lint on a single OS

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -1,6 +1,7 @@
 name: CI Checks
 
-on: [push, pull_request]
+on:
+  push:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -53,14 +53,7 @@ jobs:
       - run: cargo test
   linting:
     name: Linting
-    strategy:
-      matrix:
-        os:
-          # Check compilation works on common OSes
-          # (i.e. no path issues)
-          - ubuntu-latest
-          - macOS-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -72,14 +65,7 @@ jobs:
       - run: cargo clippy --all-targets
   formatting:
     name: Formatting
-    strategy:
-      matrix:
-        os:
-          # Check compilation works on common OSes
-          # (i.e. no path issues)
-          - ubuntu-latest
-          - macOS-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This should fix many redundant runs.