### PR TITLE
Add Dockerfile and deploy image to the GitHub Container Registry automatically

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,39 @@
+name: Docker
+
+on:
+  push:
+    branches:
+    - main
+  workflow_dispatch:
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Log in to GHCR
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: H1ghBre4k3r/y-lang
+        tags: |
+          type=raw,value=latest,enable={{is_default_branch}}
+          type=sha
+    - name: Build and Push image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64/v8
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM rust:1.67-bullseye AS builder
+
+# Copy the sources
+WORKDIR /opt/y-lang
+COPY src src
+COPY Cargo.toml Cargo.lock .
+
+# Build the compiler
+RUN cargo build --release
+
+FROM debian:bullseye-slim
+
+# Install runtime dependencies
+RUN apt-get update -y && apt-get install -y nasm
+
+# Copy the compiler
+COPY --from=builder /opt/y-lang/target/release/why /usr/local/bin/why
+
+ENTRYPOINT ["/usr/local/bin/why"]


### PR DESCRIPTION
Fixes #13.

This branch adds a Dockerfile that builds a slim image containing the `why` binary. Additionally it adds a CI workflow that automatically builds and deploy x86_64 and arm64 variants of the image to the GitHub Container Registry (GHCR).

Note that the CI workflow that deploys the image to GHCR is configured to only run on `main`, so potential problems may first become surface after merging.