### PR TITLE
Take the input file as a positional argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,11 @@ At the time of writing this, we do not provide binaries for Y. If you want to us
 You can use `why` to typecheck, interpret and compile your program:
 
 ```shell
-why -f path/to/program.why # typechecking
+why path/to/program.why # typechecking
 
-why -f path/to/program.why -r # typecheck & run/interpret
+why path/to/program.why -r # typecheck & run/interpret
 
-why -f path/to/program.why -o path/to/output # typecheck and compile
+why path/to/program.why -o path/to/output # typecheck and compile
 ```
 
 ## Operating Systems

--- a/src/bin/why.rs
+++ b/src/bin/why.rs
@@ -16,7 +16,7 @@ use y_lang::{
 #[derive(CParser, Debug)]
 #[command(author, version, about)]
 struct Cli {
-    #[arg(short, long)]
+    #[arg(index = 1)]
     file: std::path::PathBuf,
 
     #[arg(short, long)]

--- a/tests/ackermann.rs
+++ b/tests/ackermann.rs
@@ -5,7 +5,7 @@ const FILE_NAME: &str = "./examples/ackermann.why";
 #[test]
 fn interpret_ackermann() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-r"])
+        .args([FILE_NAME, "-r"])
         .output()?;
 
     assert_eq!(std::str::from_utf8(&output.stdout)?, "13");
@@ -17,7 +17,7 @@ fn interpret_ackermann() -> Result<(), Box<dyn Error>> {
 #[test]
 fn compile_and_run_ackermann() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-o", "./output/ackermann"])
+        .args([FILE_NAME, "-o", "./output/ackermann"])
         .output()?;
 
     println!("{}", std::str::from_utf8(&output.stdout)?);

--- a/tests/assignment.rs
+++ b/tests/assignment.rs
@@ -5,7 +5,7 @@ const FILE_NAME: &str = "./examples/assignment.why";
 #[test]
 fn interpret_assignment() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-r"])
+        .args([FILE_NAME, "-r"])
         .output()?;
 
     assert_eq!(std::str::from_utf8(&output.stdout)?, "13 17 42 1337");
@@ -17,7 +17,7 @@ fn interpret_assignment() -> Result<(), Box<dyn Error>> {
 #[test]
 fn compile_and_run_assignment() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-o", "./output/assignment"])
+        .args([FILE_NAME, "-o", "./output/assignment"])
         .output()?;
 
     println!("{}", std::str::from_utf8(&output.stdout)?);

--- a/tests/boolean.rs
+++ b/tests/boolean.rs
@@ -5,7 +5,7 @@ const FILE_NAME: &str = "./examples/boolean.why";
 #[test]
 fn interpret_boolean() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-r"])
+        .args([FILE_NAME, "-r"])
         .output()?;
 
     assert_eq!(
@@ -20,7 +20,7 @@ fn interpret_boolean() -> Result<(), Box<dyn Error>> {
 #[test]
 fn compile_and_run_boolean() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-o", "./output/boolean"])
+        .args([FILE_NAME, "-o", "./output/boolean"])
         .output()?;
 
     println!("{}", std::str::from_utf8(&output.stdout)?);

--- a/tests/fib.rs
+++ b/tests/fib.rs
@@ -5,7 +5,7 @@ const FILE_NAME: &str = "./examples/fib.why";
 #[test]
 fn interpret_fib() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-r"])
+        .args([FILE_NAME, "-r"])
         .output()?;
 
     assert_eq!(std::str::from_utf8(&output.stdout)?, "6765");
@@ -17,7 +17,7 @@ fn interpret_fib() -> Result<(), Box<dyn Error>> {
 #[test]
 fn compile_and_run_fib() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-o", "./output/fib"])
+        .args([FILE_NAME, "-o", "./output/fib"])
         .output()?;
 
     println!("{}", std::str::from_utf8(&output.stdout)?);

--- a/tests/functions.rs
+++ b/tests/functions.rs
@@ -5,7 +5,7 @@ const FILE_NAME: &str = "./examples/functions.why";
 #[test]
 fn interpret_functions() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-r"])
+        .args([FILE_NAME, "-r"])
         .output()?;
 
     assert_eq!(std::str::from_utf8(&output.stdout)?, "7 10 65");
@@ -17,7 +17,7 @@ fn interpret_functions() -> Result<(), Box<dyn Error>> {
 #[test]
 fn compile_and_run_functions() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-o", "./output/functions"])
+        .args([FILE_NAME, "-o", "./output/functions"])
         .output()?;
 
     println!("{}", std::str::from_utf8(&output.stdout)?);

--- a/tests/hello.rs
+++ b/tests/hello.rs
@@ -5,7 +5,7 @@ const FILE_NAME: &str = "./examples/hello.why";
 #[test]
 fn interpret_hello() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-r"])
+        .args([FILE_NAME, "-r"])
         .output()?;
 
     assert_eq!(std::str::from_utf8(&output.stdout)?, "Hello, World!");
@@ -17,7 +17,7 @@ fn interpret_hello() -> Result<(), Box<dyn Error>> {
 #[test]
 fn compile_and_run_hello() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-o", "./output/hello"])
+        .args([FILE_NAME, "-o", "./output/hello"])
         .output()?;
 
     println!("{}", std::str::from_utf8(&output.stdout)?);

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -5,7 +5,7 @@ const FILE_NAME: &str = "./examples/import.why";
 #[test]
 fn interpret_import() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-r"])
+        .args([FILE_NAME, "-r"])
         .output()?;
 
     assert_eq!(std::str::from_utf8(&output.stdout)?, "42 10");
@@ -17,7 +17,7 @@ fn interpret_import() -> Result<(), Box<dyn Error>> {
 #[test]
 fn compile_and_run_import() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-o", "./output/import"])
+        .args([FILE_NAME, "-o", "./output/import"])
         .output()?;
 
     println!("{}", std::str::from_utf8(&output.stdout)?);

--- a/tests/printi.rs
+++ b/tests/printi.rs
@@ -5,7 +5,7 @@ const FILE_NAME: &str = "./examples/printi.why";
 #[test]
 fn interpret_printi() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-r"])
+        .args([FILE_NAME, "-r"])
         .output()?;
 
     assert_eq!(std::str::from_utf8(&output.stdout)?, "3 17 42 13 69 4");
@@ -17,7 +17,7 @@ fn interpret_printi() -> Result<(), Box<dyn Error>> {
 #[test]
 fn compile_and_run_printi() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-o", "./output/printi"])
+        .args([FILE_NAME, "-o", "./output/printi"])
         .output()?;
 
     println!("{}", std::str::from_utf8(&output.stdout)?);

--- a/tests/scope.rs
+++ b/tests/scope.rs
@@ -5,7 +5,7 @@ const FILE_NAME: &str = "./examples/scope.why";
 #[test]
 fn interpret_scope() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-r"])
+        .args([FILE_NAME, "-r"])
         .output()?;
 
     assert_eq!(
@@ -20,7 +20,7 @@ fn interpret_scope() -> Result<(), Box<dyn Error>> {
 #[test]
 fn compile_and_run_scope() -> Result<(), Box<dyn Error>> {
     let output = Command::new("./target/debug/why")
-        .args(["-f", FILE_NAME, "-o", "./output/scope"])
+        .args([FILE_NAME, "-o", "./output/scope"])
         .output()?;
 
     println!("{}", std::str::from_utf8(&output.stdout)?);


### PR DESCRIPTION
To be slightly more consistent with other tools and compilers, this branch makes the input file argument positional.

In short, it turns `why -f input.why` into `why input.why`