### PR TITLE
Create multi-arch image by cross-compiling in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,8 @@ RUN arch="$(cat /tmp/y-lang-rust-target-arch)" \
   && os="$(cat /tmp/y-lang-rust-target-os)" \
   && abi="$(cat /tmp/y-lang-rust-target-abi)" \
   && target="$(cat /tmp/y-lang-rust-target)" \
-  && target_upper="$(echo "$target" | tr '[:lower:]' '[:upper:]' | sed 's/-/_/g')" \
-  && eval "CARGO_TARGET_${target_upper}_LINKER=/usr/bin/$arch-$os-$abi-ld" \
-  && cargo build --release --target "$target" \
+  && target_ld="$arch-$os-$abi-ld" \
+  && cargo build --release --target "$target" --config "target.$target.linker=\"$target_ld\"" \
   && mkdir -p bin \
   && cp target/"$target"/release/why bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,28 @@ ARG DEBIANVERSION=bullseye
 
 FROM --platform=$BUILDPLATFORM rust:${RUSTVERSION}-${DEBIANVERSION} AS builder
 
+ARG BUILDARCH
 ARG TARGETARCH
 ARG TARGETOS
 
-# Install the target toolchain
-RUN arch=$(echo ${TARGETARCH} | sed "s/arm64/aarch64/g" | sed "s/amd64/x86_64/g") \
+# Store info about target triplet
+RUN arch=$(echo ${TARGETARCH} | sed 's/arm64/aarch64/g' | sed 's/amd64/x86_64/g') \
   && vendor=unknown \
-  && os=$(echo ${TARGETOS} | tr '[:upper:]' '[:lower:]') \
+  && os="$(echo ${TARGETOS} | tr '[:upper:]' '[:lower:]')" \
   && abi=gnu \
   && target="$arch-$vendor-$os-$abi" \
-  && echo "$target" > /tmp/y-lang-rust-target-toolchain \
+  && echo "$arch" > /tmp/y-lang-rust-target-arch \
+  && echo "$os" > /tmp/y-lang-rust-target-os \
+  && echo "$abi" > /tmp/y-lang-rust-target-abi \
+  && echo "$target" > /tmp/y-lang-rust-target
+
+# Install the cross buildtools if needed (this most importantly contains the proper linker!)
+RUN if [ ${BUILDARCH} != ${TARGETARCH} ]; then \
+  apt-get update -y && apt-get install -y crossbuild-essential-$TARGETARCH; \
+fi
+
+# Install the target toolchain
+RUN target="$(cat /tmp/y-lang-rust-target)" \
   && rustup target add "$target"
 
 # Copy the sources
@@ -20,8 +32,13 @@ WORKDIR /opt/y-lang
 COPY src src
 COPY Cargo.toml Cargo.lock .
 
-# Build the compiler
-RUN target="$(cat /tmp/y-lang-rust-target-toolchain)" \
+# Build the `why` compiler (and make sure that cargo knows about the correct linker)
+RUN arch="$(cat /tmp/y-lang-rust-target-arch)" \
+  && os="$(cat /tmp/y-lang-rust-target-os)" \
+  && abi="$(cat /tmp/y-lang-rust-target-abi)" \
+  && target="$(cat /tmp/y-lang-rust-target)" \
+  && target_upper="$(echo "$target" | tr '[:lower:]' '[:upper:]' | sed 's/-/_/g')" \
+  && eval "CARGO_TARGET_${target_upper}_LINKER=/usr/bin/$arch-$os-$abi-ld" \
   && cargo build --release --target "$target" \
   && mkdir -p bin \
   && cp target/"$target"/release/why bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN arch="$(cat /tmp/y-lang-rust-target-arch)" \
   && os="$(cat /tmp/y-lang-rust-target-os)" \
   && abi="$(cat /tmp/y-lang-rust-target-abi)" \
   && target="$(cat /tmp/y-lang-rust-target)" \
-  && target_ld="$arch-$os-$abi-ld" \
-  && cargo build --release --target "$target" --config "target.$target.linker=\"$target_ld\"" \
+  && target_linker="$arch-$os-$abi-gcc" \
+  && cargo build --release --target "$target" --config "target.$target.linker=\"$target_linker\"" \
   && mkdir -p bin \
   && cp target/"$target"/release/why bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM rust:1.67-bullseye AS builder
+ARG RUSTVERSION=1.67
+ARG DEBIANVERSION=bullseye
+
+FROM rust:${RUSTVERSION}-${DEBIANVERSION} AS builder
 
 # Copy the sources
 WORKDIR /opt/y-lang
@@ -8,7 +11,7 @@ COPY Cargo.toml Cargo.lock .
 # Build the compiler
 RUN cargo build --release
 
-FROM debian:bullseye-slim
+FROM debian:${DEBIANVERSION}-slim
 
 # Install runtime dependencies
 RUN apt-get update -y && apt-get install -y nasm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
 ARG RUSTVERSION=1.67
 ARG DEBIANVERSION=bullseye
 
-FROM rust:${RUSTVERSION}-${DEBIANVERSION} AS builder
+FROM --platform=$BUILDPLATFORM rust:${RUSTVERSION}-${DEBIANVERSION} AS builder
+
+ARG TARGETARCH
+ARG TARGETOS
+
+# Install the target toolchain
+RUN arch=$(echo ${TARGETARCH} | sed "s/arm64/aarch64/g" | sed "s/amd64/x86_64/g") \
+  && vendor=unknown \
+  && os=$(echo ${TARGETOS} | tr '[:upper:]' '[:lower:]') \
+  && abi=gnu \
+  && echo "$arch-$vendor-$os-$abi" > /tmp/y-lang-rust-target-toolchain \
+  && rustup target add $(cat /tmp/y-lang-rust-target-toolchain)
 
 # Copy the sources
 WORKDIR /opt/y-lang
@@ -9,7 +20,9 @@ COPY src src
 COPY Cargo.toml Cargo.lock .
 
 # Build the compiler
-RUN cargo build --release
+RUN cargo build --target $(cat /tmp/y-lang-rust-target-toolchain)
+
+ARG DEBIANVERSION
 
 FROM debian:${DEBIANVERSION}-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ RUN arch=$(echo ${TARGETARCH} | sed "s/arm64/aarch64/g" | sed "s/amd64/x86_64/g"
   && vendor=unknown \
   && os=$(echo ${TARGETOS} | tr '[:upper:]' '[:lower:]') \
   && abi=gnu \
-  && echo "$arch-$vendor-$os-$abi" > /tmp/y-lang-rust-target-toolchain \
-  && rustup target add $(cat /tmp/y-lang-rust-target-toolchain)
+  && target="$arch-$vendor-$os-$abi" \
+  && echo "$target" > /tmp/y-lang-rust-target-toolchain \
+  && rustup target add "$target"
 
 # Copy the sources
 WORKDIR /opt/y-lang
@@ -20,7 +21,10 @@ COPY src src
 COPY Cargo.toml Cargo.lock .
 
 # Build the compiler
-RUN cargo build --target $(cat /tmp/y-lang-rust-target-toolchain)
+RUN target="$(cat /tmp/y-lang-rust-target-toolchain)" \
+  && cargo build --target "$target" \
+  && mkdir -p bin \
+  && cp target/"$target"/release/why bin
 
 ARG DEBIANVERSION
 
@@ -30,6 +34,6 @@ FROM debian:${DEBIANVERSION}-slim
 RUN apt-get update -y && apt-get install -y nasm
 
 # Copy the compiler
-COPY --from=builder /opt/y-lang/target/release/why /usr/local/bin/why
+COPY --from=builder /opt/y-lang/bin/why /usr/local/bin/why
 
 ENTRYPOINT ["/usr/local/bin/why"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY Cargo.toml Cargo.lock .
 
 # Build the compiler
 RUN target="$(cat /tmp/y-lang-rust-target-toolchain)" \
-  && cargo build --target "$target" \
+  && cargo build --release --target "$target" \
   && mkdir -p bin \
   && cp target/"$target"/release/why bin
 


### PR DESCRIPTION
This implements https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/ by always running the build stage on the host platform and then (potentially cross-)compiling to the target (`linux/amd64` and `linux/arm64/v8`).

By not using QEMU for the build, the Docker build should be considerably faster.