### PR TITLE
Check exit status and clean up test utils

### DIFF
--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{
     error::Error,
     path::Path,
-    process::{Command, Output},
+    process::{Command, Output, ExitStatus},
     str,
 };
 
@@ -28,6 +28,7 @@ pub fn check_interpretation(src_path: &Path, expected: Expected) -> Result<(), B
         .output()?;
 
     expected.assert_matches(&output)?;
+    assert!(output.status.success(), "Why interpreter exited with status {:?}", output.status.code());
 
     Ok(())
 }
@@ -40,11 +41,16 @@ pub fn check_compilation(src_path: &Path, expected: Expected) -> Result<(), Box<
         .arg(src_path)
         .output()?;
 
-    println!("{}", std::str::from_utf8(&compile_output.stdout)?);
-    assert!(compile_output.stderr.is_empty());
+    let compile_stdout = std::str::from_utf8(&compile_output.stdout)?;
+    let compile_stderr = std::str::from_utf8(&compile_output.stderr)?;
+
+    println!("{}", compile_stdout);
+    assert!(compile_stderr.is_empty(), "{}", compile_stderr);
+    assert!(compile_output.status.success(), "Why compiler exited with status {:?}", compile_output.status.code());
 
     let output = Command::new(out_path).output()?;
     expected.assert_matches(&output)?;
+    assert!(output.status.success(), "Compiled program exited with status {:?}", compile_output.status.code());
 
     Ok(())
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,7 +1,8 @@
 use std::{
     error::Error,
+    io,
     path::Path,
-    process::{Command, Output, ExitStatus},
+    process::{Command, Output},
     str,
 };
 
@@ -21,36 +22,57 @@ impl<'a> Expected<'a> {
     }
 }
 
-pub fn check_interpretation(src_path: &Path, expected: Expected) -> Result<(), Box<dyn Error>> {
-    let output = Command::new(WHY_PATH.clone())
+fn run_interpreter(src_path: &Path) -> Result<Output, io::Error> {
+    Command::new(WHY_PATH.clone())
         .arg("-r")
         .arg(src_path)
-        .output()?;
+        .output()
+}
+
+fn run_compiler(src_path: &Path, out_path: &Path) -> Result<Output, io::Error> {
+    Command::new(WHY_PATH.clone())
+        .arg("-o")
+        .arg(out_path)
+        .arg(src_path)
+        .output()
+}
+
+pub fn check_interpretation(src_path: &Path, expected: Expected) -> Result<(), Box<dyn Error>> {
+    let output = run_interpreter(src_path)?;
 
     expected.assert_matches(&output)?;
-    assert!(output.status.success(), "Why interpreter exited with status {:?}", output.status.code());
+    assert!(
+        output.status.success(),
+        "Why interpreter exited with status {:?}",
+        output.status.code()
+    );
 
     Ok(())
 }
 
 pub fn check_compilation(src_path: &Path, expected: Expected) -> Result<(), Box<dyn Error>> {
     let out_path = Path::new(OUTPUT_PATH).join(src_path.file_stem().unwrap());
-    let compile_output = Command::new(WHY_PATH.clone())
-        .arg("-o")
-        .arg(&out_path)
-        .arg(src_path)
-        .output()?;
 
+    let compile_output = run_compiler(src_path, &out_path)?;
     let compile_stdout = std::str::from_utf8(&compile_output.stdout)?;
     let compile_stderr = std::str::from_utf8(&compile_output.stderr)?;
 
     println!("{}", compile_stdout);
     assert!(compile_stderr.is_empty(), "{}", compile_stderr);
-    assert!(compile_output.status.success(), "Why compiler exited with status {:?}", compile_output.status.code());
+    assert!(
+        compile_output.status.success(),
+        "Why compiler exited with status {:?}",
+        compile_output.status.code()
+    );
 
     let output = Command::new(out_path).output()?;
+
     expected.assert_matches(&output)?;
-    assert!(output.status.success(), "Compiled program exited with status {:?}", compile_output.status.code());
+    assert!(
+        output.status.success(),
+        "Compiled program exited with status {:?}",
+        compile_output.status.code()
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This branch adds a check for the exit status (I stumbled upon this while tinkering on #16 where the tests would sometimes mysteriously pass even though something went wrong).