### PR TITLE
Outer Mutability

### DIFF
--- a/examples/mutable.why
+++ b/examples/mutable.why
@@ -1,0 +1,15 @@
+declare printi : (int) -> void
+declare print : (str) -> void
+
+let mut x := 3 
+
+{
+    x = x + 1
+
+    let x := 6
+    x = x - 3
+    printi(x)
+    print(" ")
+}
+
+printi(x)

--- a/src/ast/definition.rs
+++ b/src/ast/definition.rs
@@ -7,6 +7,7 @@ pub struct Definition<T> {
     pub ident: Ident<T>,
     pub value: Expression<T>,
     pub position: Position,
+    pub is_mutable: bool,
     pub info: T,
 }
 
@@ -16,7 +17,19 @@ impl Definition<()> {
 
         let (line, col) = pair.line_col();
 
-        let ident = Ident::from_pair(
+        let mut is_mutable = false;
+
+        let ident_or_mut = inner.next().unwrap_or_else(|| {
+            panic!(
+                "Expected lvalue or 'mut' in definition '{}' at {}:{}",
+                pair.as_str(),
+                pair.line_col().0,
+                pair.line_col().1
+            )
+        });
+
+        let ident = if ident_or_mut.as_rule() == Rule::mutKeyword {
+            is_mutable = true;
             inner.next().unwrap_or_else(|| {
                 panic!(
                     "Expected lvalue in definition '{}' at {}:{}",
@@ -24,9 +37,12 @@ impl Definition<()> {
                     pair.line_col().0,
                     pair.line_col().1
                 )
-            }),
-            file,
-        );
+            })
+        } else {
+            ident_or_mut
+        };
+
+        let ident = Ident::from_pair(ident, file);
 
         let value = inner.next().unwrap_or_else(|| {
             panic!(
@@ -42,6 +58,7 @@ impl Definition<()> {
             ident,
             value,
             position: (file.to_owned(), line, col),
+            is_mutable,
             info: (),
         }
     }

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -89,6 +89,7 @@ impl Typechecker {
                             )?),
                             source: None,
                         },
+                        false,
                     )
                 }
                 Intrinsic::Declaration(declaration) => {
@@ -102,7 +103,7 @@ impl Typechecker {
                         Self::get_type_def(&type_annotation.value, position.clone())?;
 
                     if let VariableType::Func { .. } = &type_annotation {
-                        scope.set(&ident.value, type_annotation);
+                        scope.set(&ident.value, type_annotation, false);
                     }
                 }
                 _ => {}
@@ -140,9 +141,13 @@ impl Typechecker {
 
         for (key, value) in imports {
             if module.is_wildcard {
-                scope.set(&key, value.set_source(module.clone()));
+                scope.set(&key, value.variable_type.set_source(module.clone()), false);
             } else {
-                scope.set(&format!("{path}::{key}"), value.set_source(module.clone()));
+                scope.set(
+                    &format!("{path}::{key}"),
+                    value.variable_type.set_source(module.clone()),
+                    false,
+                );
             }
         }
 
@@ -177,7 +182,7 @@ impl Typechecker {
         let type_def =
             Self::get_type_def(&type_annotation.value, type_annotation.position.clone())?;
 
-        scope.set(&ident.value, type_def);
+        scope.set(&ident.value, type_def, false);
         Ok(declaration.clone())
     }
 
@@ -257,7 +262,11 @@ impl Typechecker {
         let definition_rhs =
             self.check_expression(Some(&definition.ident), &definition.value, scope)?;
 
-        scope.set(&definition.ident.value, definition_rhs.info()._type);
+        scope.set(
+            &definition.ident.value,
+            definition_rhs.info()._type,
+            definition.is_mutable,
+        );
 
         let ident = &definition.ident;
 
@@ -269,6 +278,7 @@ impl Typechecker {
             },
             value: definition_rhs,
             position: definition.position.clone(),
+            is_mutable: definition.is_mutable,
             info: TypeInfo {
                 _type: VariableType::Void,
                 source: None,
@@ -290,7 +300,7 @@ impl Typechecker {
             });
         }
 
-        if !scope.is_in_current_scope(&ident.value) {
+        if !scope.is_mutable(&ident.value) {
             return Err(TypeError {
                 message: format!(
                     "Variable '{}' can not be modified, because it is not defined in current scope",
@@ -446,7 +456,7 @@ impl Typechecker {
                 param.type_annotation.position.clone(),
             )?;
 
-            scope.set(&param.ident.value, param_type.clone());
+            scope.set(&param.ident.value, param_type.clone(), false);
             params.push(param_type);
         }
 
@@ -458,6 +468,8 @@ impl Typechecker {
                     return_value: Box::new(type_annotation.clone()),
                     source: None,
                 },
+                // TODO: This should handle mutable definitions
+                false,
             )
         }
 

--- a/src/typechecker/typescope.rs
+++ b/src/typechecker/typescope.rs
@@ -40,16 +40,11 @@ impl TypeScope {
     }
 
     pub fn is_mutable(&self, name: &str) -> bool {
-        let scopes = self.scope_stack.clone();
-        if let Some(last) = scopes.last() {
-            if last.borrow().contains_key(name) {
-                return true;
-            }
-        }
-
-        for scope in &self.scope_stack {
+        for (index, scope) in self.scope_stack.iter().rev().enumerate() {
             if let Some(Variable { is_mutable, .. }) = scope.borrow().get(name) {
-                return *is_mutable;
+                if *is_mutable || index == 0 {
+                    return true;
+                }
             }
         }
 

--- a/src/typechecker/typescope.rs
+++ b/src/typechecker/typescope.rs
@@ -2,7 +2,13 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use super::{error::TypeError, variabletype::VariableType};
 
-type ScopeFrame = HashMap<String, VariableType>;
+#[derive(Debug, Clone)]
+pub struct Variable {
+    pub variable_type: VariableType,
+    pub is_mutable: bool,
+}
+
+type ScopeFrame = HashMap<String, Variable>;
 
 type ScopeFrameReference = Rc<RefCell<ScopeFrame>>;
 
@@ -26,18 +32,27 @@ impl TypeScope {
         scopes.reverse();
         for scope in scopes {
             if let Some(variable) = scope.borrow().get(name) {
-                return Some(variable.clone());
+                return Some(variable.variable_type.clone());
             }
         }
 
         None
     }
 
-    pub fn is_in_current_scope(&self, name: &str) -> bool {
+    pub fn is_mutable(&self, name: &str) -> bool {
         let scopes = self.scope_stack.clone();
         if let Some(last) = scopes.last() {
-            return last.borrow().contains_key(name);
+            if last.borrow().contains_key(name) {
+                return true;
+            }
         }
+
+        for scope in &self.scope_stack {
+            if let Some(Variable { is_mutable, .. }) = scope.borrow().get(name) {
+                return *is_mutable;
+            }
+        }
+
         false
     }
 
@@ -65,9 +80,13 @@ impl TypeScope {
     }
 
     /// Create a new variable on the current scope.
-    pub fn set(&mut self, name: &str, value: VariableType) {
+    pub fn set(&mut self, name: &str, value: VariableType, is_mutable: bool) {
         if let Some(scope) = self.scope_stack.last_mut() {
-            scope.borrow_mut().insert(name.to_owned(), value);
+            let variable = Variable {
+                variable_type: value,
+                is_mutable,
+            };
+            scope.borrow_mut().insert(name.to_owned(), variable);
         }
     }
 
@@ -83,8 +102,9 @@ impl TypeScope {
 
         for scope in &mut scopes {
             let mut scope = scope.borrow_mut();
-            if let Some(old_type) = scope.get(name) {
-                if *old_type != value {
+            if let Some(old_variable) = scope.get(name) {
+                let old_type = &old_variable.variable_type;
+                if old_type != &value {
                     return Err(TypeError {
                         message: format!(
                             "Could not assign variable '{name}' with type '{old_type}' a value of type '{value}'"
@@ -92,7 +112,9 @@ impl TypeScope {
                         position: position.to_owned(),
                     });
                 }
-                scope.insert(name.to_owned(), value);
+                let mut new_variable = old_variable.clone();
+                new_variable.variable_type = value;
+                scope.insert(name.to_owned(), new_variable);
 
                 break;
             }
@@ -104,7 +126,7 @@ impl TypeScope {
         Ok(())
     }
 
-    pub fn flatten(&self) -> HashMap<String, VariableType> {
+    pub fn flatten(&self) -> HashMap<String, Variable> {
         let mut entries = HashMap::default();
 
         for scope in &self.scope_stack {

--- a/src/y-lang.pest
+++ b/src/y-lang.pest
@@ -20,7 +20,9 @@ ifStmt = { "if" ~ expr ~ block ~ ("else" ~ block)? }
 
 declaration = { "declare " ~ ident ~ typeAnnotation }
 
-definition = { "let " ~ localIdent ~ ":=" ~ expr }
+definition = { "let " ~ mutKeyword? ~ localIdent ~ ":=" ~ expr }
+
+mutKeyword = { "mut " }
 
 assignment = { localIdent ~ "=" ~ expr }
 

--- a/tests/mutable.rs
+++ b/tests/mutable.rs
@@ -1,0 +1,19 @@
+use std::{error::Error, path::Path};
+
+use test_utils::{check_compilation, check_interpretation, Expected};
+
+const SRC_PATH: &str = "./examples/mutable.why";
+const EXPECTED: Expected = Expected {
+    stdout: "3 4",
+    stderr: "",
+};
+
+#[test]
+fn interpret_fib() -> Result<(), Box<dyn Error>> {
+    check_interpretation(Path::new(SRC_PATH), EXPECTED)
+}
+
+#[test]
+fn compile_and_run_fib() -> Result<(), Box<dyn Error>> {
+    check_compilation(Path::new(SRC_PATH), EXPECTED)
+}

--- a/tests/mutable.rs
+++ b/tests/mutable.rs
@@ -9,11 +9,11 @@ const EXPECTED: Expected = Expected {
 };
 
 #[test]
-fn interpret_fib() -> Result<(), Box<dyn Error>> {
+fn interpret_mutable() -> Result<(), Box<dyn Error>> {
     check_interpretation(Path::new(SRC_PATH), EXPECTED)
 }
 
 #[test]
-fn compile_and_run_fib() -> Result<(), Box<dyn Error>> {
+fn compile_and_run_mutable() -> Result<(), Box<dyn Error>> {
     check_compilation(Path::new(SRC_PATH), EXPECTED)
 }


### PR DESCRIPTION
This PR aims to allow outer mutability (i.e., allow mutations of variables which are not defined within the inner scope). 

To achieve that, I added the `mut` keyword. If a definition is parsed with a `mut` keyword, the parser marks the corresponding definition as "mutable". The `TypeScope` got adjusted to keep track of that. 

Closes #24 