### PR TITLE
Fix last features for v0.1

### DIFF
--- a/examples/functions.why
+++ b/examples/functions.why
@@ -23,3 +23,18 @@ printi(nested(a, foo))
 
 print(" ")
 printi(nested(7, (inner : (int, int) -> int): int => { inner(41, 17) }))
+
+let triple := (a: int, b: int, c: int): int => {
+    a + b + c
+}
+print(" ")
+printi(triple(1, 2, 3))
+
+let six_params := (a: int, b: int, c: int, d: int, e: str, f: bool): int => {
+    if f {
+        print(e)
+    };
+    (a + b + c) * d
+}
+print(" ")
+printi(six_params(1, 2, 3, 4, "from_function ", true))

--- a/examples/print.why
+++ b/examples/print.why
@@ -1,0 +1,18 @@
+declare print : (str) -> void
+
+print("literal ")
+
+let foo := "variable "
+print(foo)
+
+let bar := (): str => {
+    "function "
+}
+print(bar())
+
+print({
+    "block "
+})
+
+print(if true { "if " } else { "else "})
+print(if false { "if " } else { "else "})

--- a/src/asm/reg.rs
+++ b/src/asm/reg.rs
@@ -13,6 +13,10 @@ pub enum Reg {
 
     /// 2. function argument
     Rsi,
+    Esi,
+    Si,
+    Sil,
+
     /// Return value
     Rax,
     Eax,
@@ -21,18 +25,51 @@ pub enum Reg {
 
     /// Preserved. Sometimes used to store the old value of the stack pointer
     Rbp,
+    Ebp,
+    Bp,
+    Bpl,
+
     /// Stack pointer
     Rsp,
+    Esp,
+    Sp,
+    Spl,
 
     /// Scratch register
     Rcx,
+    Ecx,
+    Cx,
+    Cl,
+
     /// Scratch register
     Rdx,
+    Edx,
+    Dx,
+    Dl,
 
+    /// Scratch register
     R8,
+    R8d,
+    R8w,
+    R8b,
+
+    /// Scratch register
     R9,
+    R9d,
+    R9w,
+    R9b,
+
+    /// Scratch register
     R10,
+    R10d,
+    R10w,
+    R10b,
+
+    /// Scratch register
     R11,
+    R11d,
+    R11w,
+    R11b,
 }
 
 impl Display for Reg {
@@ -49,15 +86,49 @@ impl Display for Reg {
             Reg::Al => "al",
 
             Reg::Rsi => "rsi",
+            Reg::Esi => "esi",
+            Reg::Si => "si",
+            Reg::Sil => "sil",
+
             Reg::Rdx => "rdx",
+            Reg::Edx => "edx",
+            Reg::Dx => "dx",
+            Reg::Dl => "dl",
+
             Reg::Rbp => "rbp",
+            Reg::Ebp => "ebp",
+            Reg::Bp => "bp",
+            Reg::Bpl => "bpl",
+
             Reg::Rsp => "rsp",
+            Reg::Esp => "esp",
+            Reg::Sp => "sp",
+            Reg::Spl => "spl",
+
             Reg::Rcx => "rcx",
+            Reg::Ecx => "ecx",
+            Reg::Cx => "cx",
+            Reg::Cl => "cl",
 
             Reg::R8 => "r8",
+            Reg::R8d => "r8d",
+            Reg::R8w => "r8w",
+            Reg::R8b => "r8b",
+
             Reg::R9 => "r9",
+            Reg::R9d => "r9d",
+            Reg::R9w => "r9w",
+            Reg::R9b => "r9b",
+
             Reg::R10 => "r10",
+            Reg::R10d => "r10d",
+            Reg::R10w => "r10w",
+            Reg::R10b => "r10b",
+
             Reg::R11 => "r11",
+            Reg::R11d => "r11d",
+            Reg::R11w => "r11w",
+            Reg::R11b => "r11b",
         })
     }
 }
@@ -73,8 +144,11 @@ impl Reg {
                 1 => Dil,
                 _ => unimplemented!(),
             },
-            Rsi => match info.var_size() {
+            Rsi | Esi | Si | Sil => match info.var_size() {
                 8 => Rsi,
+                4 => Esi,
+                2 => Si,
+                1 => Sil,
                 _ => unimplemented!(),
             },
             Rax | Eax | Ax | Al => match info.var_size() {
@@ -84,36 +158,60 @@ impl Reg {
                 1 => Al,
                 _ => unimplemented!(),
             },
-            Rbp => match info.var_size() {
+            Rbp | Ebp | Bp | Bpl => match info.var_size() {
                 8 => Rbp,
+                4 => Ebp,
+                2 => Bp,
+                1 => Bpl,
                 _ => unimplemented!(),
             },
-            Rsp => match info.var_size() {
+            Rsp | Esp | Sp | Spl => match info.var_size() {
                 8 => Rsp,
+                4 => Esp,
+                2 => Sp,
+                1 => Spl,
                 _ => unimplemented!(),
             },
-            Rcx => match info.var_size() {
+            Rcx | Ecx | Cx | Cl => match info.var_size() {
                 8 => Rcx,
+                4 => Ecx,
+                2 => Cx,
+                1 => Cl,
                 _ => unimplemented!(),
             },
-            Rdx => match info.var_size() {
+            Rdx | Edx | Dx | Dl => match info.var_size() {
                 8 => Rdx,
+                4 => Edx,
+                2 => Dx,
+                1 => Dl,
                 _ => unimplemented!(),
             },
-            R8 => match info.var_size() {
+            R8 | R8d | R8w | R8b => match info.var_size() {
                 8 => R8,
+                4 => R8d,
+                2 => R8w,
+                1 => R8b,
                 _ => unimplemented!(),
             },
-            R9 => match info.var_size() {
+            R9 | R9d | R9w | R9b => match info.var_size() {
                 8 => R9,
+                4 => R9d,
+                2 => R9w,
+                1 => R9b,
                 _ => unimplemented!(),
             },
-            R10 => match info.var_size() {
+            R10 | R10d | R10w | R10b => match info.var_size() {
                 8 => R10,
+                4 => R10d,
+                2 => R10w,
+                1 => R10b,
                 _ => unimplemented!(),
             },
-            R11 => match info.var_size() {
+            R11 | R11d | R11w | R11b => match info.var_size() {
                 8 => R11,
+                4 => R11d,
+                2 => R11w,
+                1 => R11b,
                 _ => unimplemented!(),
             },
         }

--- a/src/ast/call.rs
+++ b/src/ast/call.rs
@@ -15,7 +15,7 @@ impl Call<()> {
 
         let (line, col) = pair.line_col();
 
-        let mut inner = pair.into_inner();
+        let inner = pair.into_inner();
 
         let mut params = vec![];
 

--- a/src/ast/import.rs
+++ b/src/ast/import.rs
@@ -11,7 +11,7 @@ pub struct Import {
 
 impl Import {
     pub fn from_pair(pair: Pair<Rule>, file: &str) -> Self {
-        assert_eq!(pair.as_rule(), Rule::importStmt);
+        assert_eq!(pair.as_rule(), Rule::importDirective);
         let (line, col) = pair.line_col();
 
         let mut inner = pair.into_inner();

--- a/src/ast/statement.rs
+++ b/src/ast/statement.rs
@@ -12,12 +12,12 @@ pub enum Statement<T> {
 impl Statement<()> {
     pub fn from_pair(pair: Pair<Rule>, file: &str) -> Statement<()> {
         match pair.as_rule() {
-            Rule::importStmt => Statement::Import(Import::from_pair(pair, file)),
+            Rule::importDirective => Statement::Import(Import::from_pair(pair, file)),
             Rule::declaration | Rule::definition | Rule::assignment => {
                 Statement::Intrinsic(Intrinsic::from_pair(pair, file))
             }
             Rule::expr => Statement::Expression(Expression::from_pair(pair, file)),
-            _ => todo!(),
+            rule => unreachable!("Can not parse rule {rule:?} as expression"),
         }
     }
 }

--- a/src/compiler/scope.rs
+++ b/src/compiler/scope.rs
@@ -353,7 +353,13 @@ impl Scope {
                     let source = match index {
                         0 => InstructionOperand::Register(Rdi.to_sized(info)),
                         1 => InstructionOperand::Register(Rsi.to_sized(info)),
-                        _ => todo!(),
+                        2 => InstructionOperand::Register(Rdx.to_sized(info)),
+                        3 => InstructionOperand::Register(Rcx.to_sized(info)),
+                        4 => InstructionOperand::Register(R8.to_sized(info)),
+                        5 => InstructionOperand::Register(R9.to_sized(info)),
+                        _ => unimplemented!(
+                            "More than 6 function parameters are currently not supported"
+                        ),
                     };
 
                     function_scope.add_param(&identifier.value, info.clone(), source);
@@ -571,7 +577,13 @@ impl Scope {
                     let source = match index {
                         0 => InstructionOperand::Register(Rdi.to_sized(info)),
                         1 => InstructionOperand::Register(Rsi.to_sized(info)),
-                        _ => todo!(),
+                        2 => InstructionOperand::Register(Rdx.to_sized(info)),
+                        3 => InstructionOperand::Register(Rcx.to_sized(info)),
+                        4 => InstructionOperand::Register(R8.to_sized(info)),
+                        5 => InstructionOperand::Register(R9.to_sized(info)),
+                        _ => unimplemented!(
+                            "More than 6 function parameters are currently not supported"
+                        ),
                     };
 
                     function_scope.add_param(&identifier.value, info.clone(), source);
@@ -689,14 +701,20 @@ impl Scope {
                         Call("print".to_owned()),
                     ])
                 }
-                Expression::If(_) => todo!(),
-                Expression::Binary(_) => todo!(),
-                Expression::Prefix(_) => todo!(),
-                Expression::Postfix(_) => todo!(),
-                Expression::Integer(_) => todo!(),
-                Expression::Boolean(_) => todo!(),
-                Expression::FnDef(_) => todo!(),
-                Expression::Block(_) => todo!(),
+                Expression::If(_)
+                | Expression::Binary(_)
+                | Expression::Block(_)
+                | Expression::Postfix(_) => {
+                    self.compile_expression(&param);
+                    self.instructions.append(&mut vec![
+                        Mov(Register(Rsi), Register(Rax)),
+                        Mov(Register(Rdi), Register(Rsi)),
+                        Call("str_len".to_owned()),
+                        Mov(Register(Rdx), Register(Rax)),
+                        Call("print".to_owned()),
+                    ]);
+                }
+                _ => unreachable!(),
             };
             return;
         } else if name.as_str() == "printi" {
@@ -740,7 +758,11 @@ impl Scope {
             match call.params.len() - (index + 1) {
                 0 => self.instructions.push(Pop(Rdi)),
                 1 => self.instructions.push(Pop(Rsi)),
-                _ => todo!(),
+                2 => self.instructions.push(Pop(Rdx)),
+                3 => self.instructions.push(Pop(Rcx)),
+                4 => self.instructions.push(Pop(R8)),
+                5 => self.instructions.push(Pop(R9)),
+                _ => unimplemented!("More than 6 function parameters are currently not supported"),
             }
         }
 

--- a/src/compiler/scope.rs
+++ b/src/compiler/scope.rs
@@ -271,14 +271,18 @@ impl Scope {
                     }
                 };
             }
-            Expression::Prefix(_) => todo!("Compiling prefix expressions is not supported yet!"),
+            Expression::Prefix(_) => {
+                unimplemented!("Compiling prefix expressions is not supported yet!")
+            }
             Expression::Postfix(PostfixExpr {
                 lhs,
                 op: PostfixOp::Call(call),
                 ..
             }) => match **lhs {
                 Expression::Ident(ref ident) => self.compile_fn_call(ident, call),
-                _ => todo!("Compiling calls on non-identifier expressions is not supported yet!"),
+                _ => unimplemented!(
+                    "Compiling calls on non-identifier expressions is not supported yet!"
+                ),
             },
             Expression::Integer(integer) => {
                 let value = integer.value;
@@ -512,7 +516,7 @@ impl Scope {
                 ));
             }
             Expression::Prefix(_) => {
-                todo!("Definitions cannot be generated from prefix expressions yet")
+                unimplemented!("Definitions cannot be generated from prefix expressions yet")
             }
             Expression::Postfix(postfix_expr) => {
                 let PostfixOp::Call(call) = postfix_expr.op.clone();

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -321,8 +321,8 @@ impl Interpreter {
         // let rhs = self.run_expression(&prefix_expression.rhs, scope);
 
         match prefix_expression.op {
-            PrefixOp::UnaryMinus => todo!(),
-            PrefixOp::Not => todo!(),
+            PrefixOp::UnaryMinus => unimplemented!(),
+            PrefixOp::Not => unimplemented!(),
         }
     }
 
@@ -339,7 +339,7 @@ impl Interpreter {
         match postfix_expression.op.clone() {
             PostfixOp::Call(call) => {
                 let Expression::Ident(ident) = *postfix_expression.lhs.clone() else {
-                    todo!("Calling non-identifier expressions is not supported yet!");
+                    unimplemented!("Calling non-identifier expressions is not supported yet!");
                 };
                 self.run_fn_call(&ident.value, &call, scope)
             }
@@ -396,7 +396,7 @@ impl Interpreter {
                         Expression::Postfix(postfix_expr) => {
                             print!("{}", self.run_postfix_expression(postfix_expr, scope))
                         }
-                        Expression::FnDef(_) => todo!(),
+                        _ => unreachable!(),
                     }
                 }
                 VariableValue::Void
@@ -426,7 +426,7 @@ impl Interpreter {
                         Expression::Postfix(postfix_expr) => {
                             print!("{}", self.run_postfix_expression(postfix_expr, scope))
                         }
-                        _ => todo!(),
+                        _ => unreachable!(),
                     }
                 }
                 VariableValue::Void

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -755,7 +755,7 @@ impl Typechecker {
         match postfix_expression.op {
             PostfixOp::Call(call) => {
                 let Expression::Ident(ident) = *postfix_expression.lhs else {
-                    todo!("Calls on non-identifier-expressions are not implemented yet")
+                    unimplemented!("Calls on non-identifier-expressions are not implemented yet")
                 };
                 let call = self.check_fn_call(&ident, &call, scope)?;
                 let info = call.info.clone();

--- a/src/y-lang.pest
+++ b/src/y-lang.pest
@@ -1,17 +1,17 @@
-program = _{ SOI ~ (importStmt)* ~ (stmt)* ~ EOI }
+program = _{ SOI ~ (importDirective)* ~ (stmt)* ~ EOI }
 
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
 
 COMMENT = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ( "//" ~ (!NEWLINE ~ ANY)* ~ NEWLINE ) }
 
-importStmt = {
+importDirective = {
     "import " ~ importPath
 }
 
 importPath = @{ ident ~ ("::*")? }
 
 stmt = _{ 
-    intrinsics | expr
+    (intrinsics | expr) ~ ";"?
 }
 
 intrinsics = _{ declaration | definition | assignment }

--- a/tests/print.rs
+++ b/tests/print.rs
@@ -2,18 +2,18 @@ use std::{error::Error, path::Path};
 
 use test_utils::{check_compilation, check_interpretation, Expected};
 
-const SRC_PATH: &str = "./examples/functions.why";
+const SRC_PATH: &str = "./examples/print.why";
 const EXPECTED: Expected = Expected {
-    stdout: "7 10 65 6 from_function 24",
+    stdout: "literal variable function block if else ",
     stderr: "",
 };
 
 #[test]
-fn interpret_functions() -> Result<(), Box<dyn Error>> {
+fn interpret_print() -> Result<(), Box<dyn Error>> {
     check_interpretation(Path::new(SRC_PATH), EXPECTED)
 }
 
 #[test]
-fn compile_and_run_functions() -> Result<(), Box<dyn Error>> {
+fn compile_and_run_print() -> Result<(), Box<dyn Error>> {
     check_compilation(Path::new(SRC_PATH), EXPECTED)
 }


### PR DESCRIPTION
This PR aims to fix all features for `v0.1.0` of Y. This includes (but is not limited to): 

- add all registers (up until R11) to the `asm` module
- implement functions with up to 6 parameters
- allow termination of statements with a semicolon
  - this fixes a bug where the following code did not type check
```diff
- if true {}
  (1 + 3) // this gets parsed as call to result of expression above

+ if true {}; // <- terminate expression explicitly
  (1 + 3) // this works no
```
- implement all variants of passing a string to `print`
- changes `todo!` to `unimplemented!` to indicate future features
