### PR TITLE
References

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,21 @@ Y supports a couple of primitive types which are build directly into the lanuage
 -   `void` for "empty" values
 -   functions (see later for information on how to declare a function type)
 
+Furthermore, you can specify references as function parameters. References work like regular variables (or rather like their "underlying" variable), but they also effect their "source":
+
+```why
+// declare function with parameter of type integer-reference
+let foo := (a: &int): void => {
+    a = a * 2 // <- this assigns a new value to the underlying variable of `a`
+}
+
+let bar := 2
+
+foo(bar) // pass `bar` as a parameter, which will automatically be converted to a reference
+```
+
+Currently, you can only pass identifiers as references.
+
 More complex types are subject for futures features.
 
 ### Mutablity

--- a/examples/references.why
+++ b/examples/references.why
@@ -1,10 +1,11 @@
-/* import std::* */
+import std::*
 
-let addTwo := (x: &int): void => {
-    x = x + 2
+let addTwo := (x: &int): int => {
+    x;
+    2
 }
 
 let a := 2
-addTwo(a)
+printi(addTwo(a))
 
 /* printi(a) */

--- a/examples/references.why
+++ b/examples/references.why
@@ -1,0 +1,10 @@
+/* import std::* */
+
+let addTwo := (x: &int): void => {
+    x = x + 2
+}
+
+let a := 2
+addTwo(a)
+
+/* printi(a) */

--- a/examples/references.why
+++ b/examples/references.why
@@ -1,11 +1,12 @@
 import std::*
 
-let addTwo := (x: &int): int => {
-    x;
-    2
+let addTwo := (x: &int): void => {
+    x = x * 3
+    x = (x + 2) * x
 }
 
-let a := 2
-printi(addTwo(a))
+let a := 3 
 
-/* printi(a) */
+addTwo(a)
+
+printi(a)

--- a/examples/references.why
+++ b/examples/references.why
@@ -1,12 +1,12 @@
 import std::*
 
-let addTwo := (x: &int): void => {
+let foo := (x: &int): void => {
     x = x * 3
     x = (x + 2) * x
 }
 
 let a := 3 
 
-addTwo(a)
+foo(a)
 
 printi(a)

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -14,6 +14,7 @@ pub enum Type {
         item_type: Box<Type>,
         size: Integer<()>,
     },
+    Reference(Box<Type>),
 }
 
 impl Type {
@@ -60,6 +61,14 @@ impl Type {
                     item_type: Box::new(item_type),
                     size,
                 }
+            }
+            Rule::reference => {
+                let mut inner = pair.into_inner();
+
+                let item_type = inner.next().unwrap();
+                let item_type = Type::from_pair(item_type);
+
+                Self::Reference(Box::new(item_type))
             }
             _ => unreachable!(),
         }

--- a/src/compiler/scope.rs
+++ b/src/compiler/scope.rs
@@ -985,16 +985,43 @@ impl Scope {
             }
             Expression::Ident(identifier) => {
                 let info = &identifier.info;
-                if let Some(variable) = self.variables.get(&identifier.value) {
-                    self.instructions
-                        .push(Comment(format!("{} = {value:?}", identifier.value)));
-                    self.instructions.push(Mov(
-                        Memory(
-                            InstructionSize::from(info.clone()),
-                            format!("{}-{}", Rbp, variable.offset),
-                        ),
-                        Register(Rax.to_sized(info)),
-                    ));
+                let Some(variable) = self.variables.get(&identifier.value) else {
+                    unreachable!();
+                };
+
+                match &variable._type {
+                    // if we have a reference as an lvalue, we first need to load the address of it
+                    VariableType::Reference(var_type) => {
+                        let info = TypeInfo {
+                            _type: var_type.as_ref().clone(),
+                            source: None,
+                        };
+                        self.instructions
+                            .push(Comment(format!("{} = {value:?}", identifier.value)));
+                        self.instructions.push(Mov(
+                            Register(Rcx),
+                            Memory(
+                                InstructionSize::from(info.clone()),
+                                format!("{}-{}", Rbp, variable.offset),
+                            ),
+                        ));
+                        self.instructions.push(Mov(
+                            Memory(InstructionSize::from(info.clone()), format!("{}", Rcx)),
+                            Register(Rax.to_sized(&info)),
+                        ));
+                    }
+                    // in every other case, we can just store it on the stack
+                    _ => {
+                        self.instructions
+                            .push(Comment(format!("{} = {value:?}", identifier.value)));
+                        self.instructions.push(Mov(
+                            Memory(
+                                InstructionSize::from(info.clone()),
+                                format!("{}-{}", Rbp, variable.offset),
+                            ),
+                            Register(Rax.to_sized(info)),
+                        ));
+                    }
                 }
             }
             _ => {}
@@ -1063,12 +1090,23 @@ impl Scope {
         }
 
         let VariableType::Func { params, .. }= &ident.info._type else {
-            panic!();
+            unreachable!("Trying to call a non-function expression");
         };
 
         for (index, param) in call.params.iter().enumerate() {
+            // if the type of the parameter is a reference, we need to load the address of it
             if let VariableType::Reference(_) = params[index] {
-                todo!();
+                let Expression::Ident(Ident { value, .. }) = &call.params[index] else {
+                    unimplemented!("Passing non-identifiers as references is currently not supported!");
+                };
+
+                let Some(Variable { offset, ..}) = self.variables.get(value) else {
+                    unreachable!()
+                };
+
+                self.instructions.push(Mov(Register(Rax), Register(Rbp)));
+                self.instructions
+                    .push(Sub(Register(Rax), Immediate(*offset as i64)));
             } else {
                 self.compile_expression(param);
             }

--- a/src/compiler/scope.rs
+++ b/src/compiler/scope.rs
@@ -125,7 +125,8 @@ impl Scope {
                 | VariableType::Any
                 | VariableType::Unknown
                 | VariableType::Func { .. }
-                | VariableType::ArraySlice(_) => {
+                | VariableType::ArraySlice(_)
+                | VariableType::Reference(_) => {
                     self.stack_offset += info.var_size();
 
                     let variable = Variable {
@@ -409,6 +410,19 @@ impl Scope {
                             self.instructions.push(Mov(Register(Rax), Register(Rbp)));
                             self.instructions
                                 .push(Sub(Register(Rax), Immediate(offset as i64)));
+                        }
+                        VariableType::Reference(_) => {
+                            self.instructions.push(Mov(
+                                Register(Rax.to_sized(info)),
+                                Memory(
+                                    InstructionSize::from(info.clone()),
+                                    format!("{Rbp}-{offset}"),
+                                ),
+                            ));
+                            self.instructions.push(Mov(
+                                Register(Rax.to_sized(info)),
+                                Memory(InstructionSize::from(info.clone()), format!("{Rax}")),
+                            ));
                         }
                         _ => {
                             self.instructions.push(Mov(
@@ -728,7 +742,8 @@ impl Scope {
                     | VariableType::Any
                     | VariableType::Unknown
                     | VariableType::Func { .. }
-                    | VariableType::ArraySlice(_) => {
+                    | VariableType::ArraySlice(_)
+                    | VariableType::Reference(_) => {
                         self.stack_offset += call.info.var_size();
                         let variable = Variable {
                             offset: self.stack_offset,
@@ -1048,6 +1063,7 @@ impl Scope {
         }
 
         for param in call.params.iter() {
+            println!("{param:#?}");
             self.compile_expression(param);
             self.instructions.push(Push(Rax));
         }

--- a/src/compiler/scope.rs
+++ b/src/compiler/scope.rs
@@ -1062,9 +1062,17 @@ impl Scope {
             return;
         }
 
-        for param in call.params.iter() {
-            println!("{param:#?}");
-            self.compile_expression(param);
+        let VariableType::Func { params, .. }= &ident.info._type else {
+            panic!();
+        };
+
+        for (index, param) in call.params.iter().enumerate() {
+            if let VariableType::Reference(_) = params[index] {
+                todo!();
+            } else {
+                self.compile_expression(param);
+            }
+
             self.instructions.push(Push(Rax));
         }
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -665,6 +665,9 @@ impl Typechecker {
                     },
                 })
             }
+            Type::Reference(type_) => Ok(VariableType::Reference(Box::new(Self::get_type_def(
+                type_, position,
+            )?))),
         }
     }
 
@@ -688,7 +691,7 @@ impl Typechecker {
                 param.type_annotation.position.clone(),
             )?;
 
-            scope.set(&param.ident.value, param_type.clone(), false);
+            scope.set(&param.ident.value, param_type.clone(), true);
             params.push(param_type);
         }
 
@@ -845,7 +848,7 @@ impl Typechecker {
 
         match binary_expression.op {
             BinaryOp::Equal => {
-                if l_type != r_type {
+                if l_type.convert_to(&r_type).is_err() {
                     return Err(TypeError {
                         message: format!(
                         "Left and right value of binary operation do not match! ('{l_type}' and '{r_type}')"
@@ -865,7 +868,9 @@ impl Typechecker {
                 })
             }
             BinaryOp::LessThan | BinaryOp::GreaterThan => {
-                if l_type != VariableType::Int || r_type != VariableType::Int {
+                if l_type.convert_to(&VariableType::Int).is_err()
+                    || r_type.convert_to(&VariableType::Int).is_err()
+                {
                     return Err(TypeError {
                         message: format!(
                             "Invalid types for binary operation '{}'. Got '{}' and '{}'",
@@ -886,14 +891,14 @@ impl Typechecker {
                 })
             }
             BinaryOp::Plus | BinaryOp::Minus | BinaryOp::Times | BinaryOp::DividedBy => {
-                if l_type != VariableType::Int {
+                if l_type.convert_to(&VariableType::Int).is_err() {
                     return Err(TypeError {
                         message: format!(
                         "Left value of numeric binary operation has to be of type Int. Found '{l_type}'"
                     ),
                         position: lhs.position(),
                     });
-                } else if r_type != VariableType::Int {
+                } else if r_type.convert_to(&VariableType::Int).is_err() {
                     return Err(TypeError {
                         message: format!(
                         "Right value of numeric binary operation has to be of type Int. Found '{r_type}'"

--- a/src/typechecker/typescope.rs
+++ b/src/typechecker/typescope.rs
@@ -107,7 +107,7 @@ impl TypeScope {
             let mut scope = scope.borrow_mut();
             if let Some(old_variable) = scope.get(name) {
                 let old_type = &old_variable.variable_type;
-                if old_type != &value {
+                if old_type.convert_to(&value).is_err() {
                     return Err(TypeError {
                         message: format!(
                             "Could not assign variable '{name}' with type '{old_type}' a value of type '{value}'"

--- a/src/typechecker/variabletype.rs
+++ b/src/typechecker/variabletype.rs
@@ -23,6 +23,7 @@ pub enum VariableType {
         item_type: Box<VariableType>,
         size: usize,
     },
+    Reference(Box<VariableType>),
 }
 
 pub struct VariableParseError(String);
@@ -63,6 +64,7 @@ impl Display for VariableType {
             } => format!("{params:?} -> {return_value:?}"),
             ArraySlice(item_type) => format!("&[{item_type}]"),
             TupleArray { item_type, size } => format!("[{item_type}; {size}]"),
+            Reference(item_type) => format!("&{item_type}"),
         };
 
         f.write_str(value)
@@ -85,6 +87,7 @@ impl VariableType {
             VariableType::Func { .. } => 8,
             VariableType::ArraySlice(_) => 8,
             VariableType::TupleArray { .. } => 8,
+            VariableType::Reference(_) => 8,
         }
     }
 
@@ -143,6 +146,8 @@ impl VariableType {
                     Err(VariableConversionError)
                 }
             }
+            (Reference(inner), right) => inner.convert_to(right),
+            (left, Reference(inner)) => left.convert_to(inner),
             // TODO: Allow conversion of same-sized strings to tuple arrays
             // (Str, TupleArray { size, .. }) => todo!(),
             (left, right) => {

--- a/src/y-lang.pest
+++ b/src/y-lang.pest
@@ -38,7 +38,9 @@ fnType = { "(" ~ ( variableType ~ ("," ~ variableType )* )? ~ ")" ~ "->" ~ typeN
 
 variableType = _{ arrayType | primtiveType }
 
-primtiveType = _{ typeName | fnType }
+primtiveType = _{ typeName | fnType | reference }
+
+reference = { "&" ~ typeName }
 
 arrayType = _{ tupleArray | arraySlice }
 

--- a/src/y-lang.pest
+++ b/src/y-lang.pest
@@ -64,6 +64,7 @@ expr = { prefix* ~ primaryExpr ~ postfix* ~ (infix ~ prefix* ~ primaryExpr ~ pos
     prefix = _{ unaryMinus | not }
         unaryMinus = { "-" }
         not = { "!" }
+        ref = { "?" }
     postfix = _{ call | indexing }
         call = { "(" ~ ( expr ~ ("," ~ expr)* )? ~ ")" }
         indexing = { "[" ~ expr ~ "]" }

--- a/tests/references.rs
+++ b/tests/references.rs
@@ -1,0 +1,14 @@
+use std::{error::Error, path::Path};
+
+use test_utils::{check_compilation, Expected};
+
+const SRC_PATH: &str = "./examples/references.why";
+const EXPECTED: Expected = Expected {
+    stdout: "99",
+    stderr: "",
+};
+
+#[test]
+fn compile_and_run_references() -> Result<(), Box<dyn Error>> {
+    check_compilation(Path::new(SRC_PATH), EXPECTED)
+}


### PR DESCRIPTION
This PR introduces references. References can be used as function parameters (or rather as the type of a function parameter). They act like the underlying variable type, but mutations to them modify the passed in variable. E.g.,

```why
import std::*

let addTwo := (x: &int): void => {
    x = x * 3
    x = (x + 2) * x
}

let a := 3 

addTwo(a)

printi(a) // <- this will print "99"
```

Closes #22 